### PR TITLE
Swift cocoapods.review

### DIFF
--- a/helloworld-ios-app.xcodeproj/project.pbxproj
+++ b/helloworld-ios-app.xcodeproj/project.pbxproj
@@ -352,7 +352,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/helloworld-ios-app/helloworld-ios-app-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.feedhenry.Helloworld-app-iOS";
 				PRODUCT_NAME = "helloworld-ios-app";
 			};
@@ -370,7 +370,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/helloworld-ios-app/helloworld-ios-app-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.feedhenry.Helloworld-app-iOS";
 				PRODUCT_NAME = "helloworld-ios-app";
 			};

--- a/helloworld-ios-app.xcodeproj/project.pbxproj
+++ b/helloworld-ios-app.xcodeproj/project.pbxproj
@@ -15,12 +15,6 @@
 		48ED7C591C031A02000A368F /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 48ED7C581C031A02000A368F /* Storyboard.storyboard */; };
 		48ED7C5D1C031AD2000A368F /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C5C1C031AD2000A368F /* libxml2.tbd */; };
 		48ED7C5F1C031AD8000A368F /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C5E1C031AD8000A368F /* libz.tbd */; };
-		48ED7C611C031C3C000A368F /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C601C031C3C000A368F /* CFNetwork.framework */; };
-		48ED7C631C031CA5000A368F /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C621C031CA5000A368F /* SystemConfiguration.framework */; };
-		48ED7C651C031CAC000A368F /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C641C031CAC000A368F /* MobileCoreServices.framework */; };
-		48ED7C671C031CB8000A368F /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C661C031CB8000A368F /* CoreGraphics.framework */; };
-		48ED7C691C031CC0000A368F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C681C031CC0000A368F /* UIKit.framework */; };
-		48ED7C6B1C031CCB000A368F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C6A1C031CCB000A368F /* Foundation.framework */; };
 		48ED7C6F1C031F01000A368F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 48ED7C6E1C031F01000A368F /* LaunchScreen.storyboard */; };
 		EFD72862E15513B4F5617CA1 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD9531BB79504855123D25C1 /* Pods.framework */; };
 /* End PBXBuildFile section */
@@ -36,12 +30,6 @@
 		48ED7C581C031A02000A368F /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = SOURCE_ROOT; };
 		48ED7C5C1C031AD2000A368F /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		48ED7C5E1C031AD8000A368F /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		48ED7C601C031C3C000A368F /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
-		48ED7C621C031CA5000A368F /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		48ED7C641C031CAC000A368F /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
-		48ED7C661C031CB8000A368F /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		48ED7C681C031CC0000A368F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		48ED7C6A1C031CCB000A368F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		48ED7C6E1C031F01000A368F /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = SOURCE_ROOT; };
 		DCFC23E1110BD0CAE9238160 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		DD9531BB79504855123D25C1 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -52,12 +40,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48ED7C6B1C031CCB000A368F /* Foundation.framework in Frameworks */,
-				48ED7C691C031CC0000A368F /* UIKit.framework in Frameworks */,
-				48ED7C671C031CB8000A368F /* CoreGraphics.framework in Frameworks */,
-				48ED7C651C031CAC000A368F /* MobileCoreServices.framework in Frameworks */,
-				48ED7C631C031CA5000A368F /* SystemConfiguration.framework in Frameworks */,
-				48ED7C611C031C3C000A368F /* CFNetwork.framework in Frameworks */,
 				48ED7C5F1C031AD8000A368F /* libz.tbd in Frameworks */,
 				48ED7C5D1C031AD2000A368F /* libxml2.tbd in Frameworks */,
 				EFD72862E15513B4F5617CA1 /* Pods.framework in Frameworks */,
@@ -103,12 +85,6 @@
 		48ED7C701C0322CE000A368F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				48ED7C6A1C031CCB000A368F /* Foundation.framework */,
-				48ED7C681C031CC0000A368F /* UIKit.framework */,
-				48ED7C661C031CB8000A368F /* CoreGraphics.framework */,
-				48ED7C641C031CAC000A368F /* MobileCoreServices.framework */,
-				48ED7C621C031CA5000A368F /* SystemConfiguration.framework */,
-				48ED7C601C031C3C000A368F /* CFNetwork.framework */,
 				48ED7C5E1C031AD8000A368F /* libz.tbd */,
 				48ED7C5C1C031AD2000A368F /* libxml2.tbd */,
 				DD9531BB79504855123D25C1 /* Pods.framework */,

--- a/helloworld-ios-app.xcodeproj/project.pbxproj
+++ b/helloworld-ios-app.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		4845C37D1C495763002F80E5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845C37C1C495763002F80E5 /* AppDelegate.swift */; };
 		4845C37F1C49576A002F80E5 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845C37E1C49576A002F80E5 /* HomeViewController.swift */; };
 		4845C3811C495774002F80E5 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4845C3801C495774002F80E5 /* Images.xcassets */; };
-		4845C3831C49579D002F80E5 /* helloworld-ios-app-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4845C3821C49579D002F80E5 /* helloworld-ios-app-Info.plist */; };
 		4845C3851C4957A4002F80E5 /* fhconfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4845C3841C4957A4002F80E5 /* fhconfig.plist */; };
 		48ED7C591C031A02000A368F /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 48ED7C581C031A02000A368F /* Storyboard.storyboard */; };
 		48ED7C5D1C031AD2000A368F /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 48ED7C5C1C031AD2000A368F /* libxml2.tbd */; };
@@ -165,7 +164,6 @@
 				48ED7C6F1C031F01000A368F /* LaunchScreen.storyboard in Resources */,
 				4845C3851C4957A4002F80E5 /* fhconfig.plist in Resources */,
 				4845C3811C495774002F80E5 /* Images.xcassets in Resources */,
-				4845C3831C49579D002F80E5 /* helloworld-ios-app-Info.plist in Resources */,
 				48ED7C591C031A02000A368F /* Storyboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/helloworld-ios-app/HomeViewController.swift
+++ b/helloworld-ios-app/HomeViewController.swift
@@ -27,10 +27,9 @@ class HomeViewController: UIViewController {
         super.viewDidLoad()
 
         // Initialized cloud connection
-        FH.init {
-            (resp: Response, error: NSError?) -> Void in
-            if let _ = error {
-                print("FH init failed. Error = \(resp.rawResponseAsString)")
+        FH.init {(resp: Response, error: NSError?) -> Void in
+            if let error = error {
+                print("FH init failed. Error = \(error)")
                 self.result.text = "Please fill in fhconfig.plist file."
             }
             print("initialized OK")
@@ -44,9 +43,9 @@ class HomeViewController: UIViewController {
 
         let args = ["hello": name.text ?? "world"]
 
-        FH.cloud("hello", method: HTTPMethod.POST, args: args, headers: nil, completionHandler:
-        {
-            (resp: Response, error: NSError?) -> Void in
+        FH.cloud("hello", method: HTTPMethod.POST,
+            args: args, headers: nil,
+            completionHandler: {(resp: Response, error: NSError?) -> Void in
             if let _ = error {
                 print("initialize fail, \(resp.rawResponseAsString)")
                 self.button.hidden = true

--- a/helloworld-ios-app/helloworld-ios-app-Info.plist
+++ b/helloworld-ios-app/helloworld-ios-app-Info.plist
@@ -50,13 +50,13 @@
 
     <key>UILaunchStoryboardName</key>
     <string>LaunchScreen</string>
-    <!--
+
      <key>NSAppTransportSecurity</key>
      <dict>
      <key>NSAllowsArbitraryLoads</key>
      <true/>
      </dict>
-     -->
+     
 
 </dict>
 </plist>


### PR DESCRIPTION
@danielpassos Nice work!
Here is a PR for my review:
- I notice a problem in aerogear-ios-http when passing a malformed URL (error case when fhconfig has still `replace me` value). This should be fixed: https://github.com/aerogear/aerogear-ios-http/pull/64
- I remove a CocoaPods warning by leaving OTHR_LDFLAGS to $(inherited)
- also the error is now available in error rather then fetching it from the Response.

